### PR TITLE
Implemented new Regex and tests

### DIFF
--- a/server/slack/commands.go
+++ b/server/slack/commands.go
@@ -57,13 +57,14 @@ func RegisterScript(script Script) {
 }
 
 // HandleMentionEvent parses the mention of the app in Slack and
-// matches it to the assoociated command, running the command if the
+// matches it to the associated command, running the command if the
 // function is available. If not, it sends a message back to Slack to
 // indicate it doesn't exist.
 func HandleMentionEvent(event *slackevents.AppMentionEvent) {
 
 	// Strip @bot-name out
-	re, err := regexp.Compile(`^<@.*> *`)
+	// regex matches anything that is not a space-character (\r, \n, \t, ' '), including the '<' characters
+	re, err := regexp.Compile(`^@\S* *`)
 	if err != nil {
 		fmt.Println("error parsing command", err.Error())
 	}

--- a/server/slack/commands_test.go
+++ b/server/slack/commands_test.go
@@ -1,0 +1,48 @@
+package slack
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func Test_match(t *testing.T) {
+	// ! `HandleMentionEvent` is not currently unit-testable d/t integration with `api.#` and `script.#` methods
+	// ? Build out with interfaces to allow for mocking?
+	
+	// TODO: Make test integrate with `HandleMentionEvent`
+	
+	type test struct {
+		content string
+	}
+	matchers := []string{"help", "set", "unset"}
+	tt := []test{
+		{"@Deskmate help"},
+		{"@deskmate help"},
+		{"@<U123456> help"},
+		{"@Deskmate set"},
+		{"@deskmate set"},
+		{"@<U123456> set"},
+		{"@Deskmate unset"},
+		{"@deskmate unset"},
+		{"@<U123456> unset"},
+	}
+
+	// re, err := regexp.Compile(`^<{0,1}@.*>{0,1} *`)
+	re, err := regexp.Compile(`^@\S* *`)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	for i := 0; i < len(matchers); i++ {
+		for j := 0; j < 3; j++ { // loop through various mentions, only 3 variations
+			c := tt[j + i * 3].content
+			fmt.Println(re.FindString(c))
+			c = re.ReplaceAllString(c, "")
+			if !match(matchers[i], c) {
+				t.Errorf("%s did not match regex as expected", c)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Issue with previous regex was `.*` which, when no `>` was found, would match the whole string, thereby replacing the whole string and ending up with an empty string provided as the `content` arg to the `match()` function.

New regex will match only up to the first character of the word following the bot invocation, as opposed to matching the entirety of the string