### PR TITLE
Dockerfile unified, both ports reachable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+############################
+# STEP 1 build executable binary
+############################
+FROM golang@sha256:0991060a1447cf648bab7f6bb60335d1243930e38420bee8fec3db1267b84cfa as zendesk
+
+
+WORKDIR $GOPATH/src/github.com/tylerconlee/Deskmate/graphql
+COPY graphql .
+# Fetch dependencies.
+# Using go get.
+RUN go mod download
+RUN go mod verify
+# Build the binary.
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/zendesk
+
+##############################
+# STEP 3 build out REST server
+##############################
+
+FROM golang as server
+
+WORKDIR $GOPATH/src/github.com/tylerconlee/Deskmate/server
+COPY server .
+# Fetch dependencies.
+# Using go get.
+
+
+# # need ssh key here to do this part -- it gets removed because this is an intermediate container
+# # default value is the contents of a file where the access token is stored:
+#     # in my case, this is "$HOME/pwds/Dockerfile-access"
+# ARG ACCESS_TOKEN=$(cat $HOME/pwds/Dockerfile-access.txt)
+# # use a github access token to access the repositories
+# RUN git config --global url."https://$(ACCESS_TOKEN):@github.com/".insteadOf "https://github.com/"
+
+RUN go get ./
+# Build the binary.
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/server
+
+
+#################################
+# STEP 3 create permissioned user
+#################################
+FROM golang@sha256:0991060a1447cf648bab7f6bb60335d1243930e38420bee8fec3db1267b84cfa  AS user
+# Install git + SSL ca certificates.
+# Git is required for fetching the dependencies.
+# Ca-certificates is required to call HTTPS endpoints.
+RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
+# Create appuser
+ENV USER=appuser
+ENV UID=10001
+
+
+# See https://stackoverflow.com/a/55757473/12429735RUN 
+RUN adduser \    
+    --disabled-password \    
+    --gecos "" \    
+    --home "/nonexistent" \    
+    --shell "/sbin/nologin" \    
+    --no-create-home \    
+    --uid "${UID}" \    
+    "${USER}"
+
+############################
+# STEP 2 build a small image
+############################
+# Can't run from sratch, need to be able to `chmod`
+FROM alpine
+# Copy our static executable.
+# Import from builder.
+COPY --from=user /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=user /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=user /etc/passwd /etc/passwd
+COPY --from=user /etc/group /etc/group
+
+COPY --from=zendesk /go/bin/zendesk /go/bin/zendesk
+COPY --from=server /go/bin/server /go/bin/server
+# Run the zendesk binary.
+
+# Copy the command to run both servers at startup
+COPY serverStart.sh /scripts/serverStart.sh
+RUN ["chmod", "+x", "/scripts/serverStart.sh"]
+
+# Use an unprivileged user.
+USER appuser:appuser
+EXPOSE 8090
+EXPOSE 8080
+
+ENTRYPOINT ["/scripts/serverStart.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/s
 #################################
 # STEP 3 create permissioned user
 #################################
-FROM golang@sha256:0991060a1447cf648bab7f6bb60335d1243930e38420bee8fec3db1267b84cfa  AS user
+FROM alpine AS user
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.
 # Ca-certificates is required to call HTTPS endpoints.

--- a/serverStart.sh
+++ b/serverStart.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+/go/bin/zendesk&
+/go/bin/server
+echo "servers running"


### PR DESCRIPTION
It should be noted that we cannot use a scratch container, as we have to
use `sh` to run the server startup command and `chmod` executable
permissions. Additionally, the `server` pkg has an error in the
`server/slack/connect.go` file that was panicking and preventing the
container from starting either `server` or `zendesk`.
I created a debug environment to test, and both ports were reachable in
that environment.
